### PR TITLE
support for legacy mysql/mariadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
-<!--
-Avoid using this README file for information that is maintained or published elsewhere, e.g.:
+# MySQL Test Application
 
-* metadata.yaml > published on Charmhub
-* documentation > published on (or linked to from) Charmhub
-* detailed contribution guide > documentation or CONTRIBUTING.md
+MySQL stack tester charm - this is a simple application used exclusively for integrations test of
+[mysql-k8s][mysql-k8s], [mysql][mysql], [mysql-router-k8s][mysql-router-k8s],
+[mysql-router][mysql-router], [mysql-bundle-k8s][mysql-bundle-k8s] and
+[mysql-bundle][mysql-bundle].
 
-Use links instead.
--->
+## Relations
 
-# mysql-test-app
+This charm implements relations interfaces:
+* database
+* mysql (legacy)
 
-Charmhub package name: operator-template
-More information: https://charmhub.io/mysql-test-app
+On using the `mysql` legacy relation interface with either [mysql] or [mysql-k8s] charms, its
+necessary to config the database name with:
 
-Describe your charm in one or two sentences.
+```shell
+> juju config mysql-k8s mysql-interface-database=continuous_writes_database
+```
 
-## Other resources
+## Actions
 
-<!-- If your charm is documented somewhere else other than Charmhub, provide a link separately. -->
+Actions are listed on [actions page](https://charmhub.io/mysql-test-app/actions)
 
-- [Read more](https://example.com)
 
-- [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+[mysql-k8s]: https://charmhub.io/mysql-k8s
+[mysql]: https://charmhub.io/mysql
+[mysql-router-k8s]: https://charmhub.io/mysql-router-k8s
+[mysql-router]: https://charmhub.io/mysql-router?channel=dpe/edge
+[mysql-bundle-k8s]: https://charmhub.io/mysql-bundle-k8s
+[mysql-bundle]: https://charmhub.io/mysql-bundle
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+## References
+
+* [MySQL Test App at Charmhub](https://charmhub.io/mysql-test-app)

--- a/actions.yaml
+++ b/actions.yaml
@@ -27,3 +27,5 @@ get-session-ssl-cipher:
 get-server-certificate:
   description: Retrieve server certificate in pem format
 
+get-legacy-mysql-credentials:
+  description: Get the credentials for the legacy mysql user

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@
 
 name: mysql-test-app
 description: |
-  An application charm used in high availability MySQL k8s integration tests.
+  An application charm used in high availability MySQL k8s/vm integration tests.
 summary: |
   Data platform libs application meant to be used
   only for testing high availability of the MySQL charm.
@@ -12,6 +12,8 @@ requires:
   database:
     interface: mysql_client
     limit: 1
+  mysql:
+    interface: mysql
 
 peers:
   application-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -302,7 +302,6 @@ class MySQLTestApplication(CharmBase):
             return
         if self.unit.is_leader():
             self.app_peer_data["database-start"] = "true"
-        self.unit.status = ActiveStatus()
 
     def _on_endpoints_changed(self, _) -> None:
         """Handle the database endpoints changed event."""
@@ -319,6 +318,8 @@ class MySQLTestApplication(CharmBase):
                 self.app_peer_data[RANDOM_VALUE_KEY] = value
                 # flag should be picked up just once
                 self.app_peer_data["database-start"] = "done"
+
+            self.unit.status = ActiveStatus()
 
     def _on_relation_broken(self, _) -> None:
         """Handle the database relation broken event."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -187,9 +187,6 @@ class MySQLTestApplication(CharmBase):
 
     def _stop_continuous_writes(self) -> Optional[int]:
         """Stop continuous writes to the MySQL cluster and return the last written value."""
-        if not self._database_config:
-            return None
-
         if not self.unit_peer_data.get(PROC_PID_KEY):
             return None
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -265,8 +265,11 @@ class MySQLTestApplication(CharmBase):
     # ==============
     def _on_start(self, _) -> None:
         """Handle the start event."""
-        self.unit.set_workload_version("0.0.1")
-        self.unit.status = WaitingStatus()
+        self.unit.set_workload_version("0.0.2")
+        if self._database_config:
+            self.unit.status = ActiveStatus()
+        else:
+            self.unit.status = WaitingStatus()
 
     def _on_clear_continuous_writes_action(self, _) -> None:
         """Handle the clear continuous writes action event."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -209,7 +209,7 @@ class MySQLTestApplication(CharmBase):
         return last_written_value
 
     def _max_written_value(self) -> int:
-        """Return the count of rows in the continuous writes table."""
+        """Return the max value in the continuous writes table."""
         if not self._database_config:
             return -1
 
@@ -219,7 +219,7 @@ class MySQLTestApplication(CharmBase):
             )
             return cursor.fetchone()[0]
 
-    def _create_test_table(self, cursor) -> None:
+    def _create_random_value_table(self, cursor) -> None:
         """Create a test table in the database."""
         cursor.execute(
             (
@@ -230,7 +230,7 @@ class MySQLTestApplication(CharmBase):
             )
         )
 
-    def _insert_test_data(self, cursor, random_value: str) -> None:
+    def _insert_random_value(self, cursor, random_value: str) -> None:
         """Insert the provided random value into the test table in the database."""
         cursor.execute(f"INSERT INTO `{RANDOM_VALUE_TABLE_NAME}`(data) VALUES('{random_value}')")
 
@@ -248,9 +248,9 @@ class MySQLTestApplication(CharmBase):
             for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
                 with attempt:
                     with MySQLConnector(self._database_config) as cursor:
-                        self._create_test_table(cursor)
+                        self._create_random_value_table(cursor)
                         random_value = self._generate_random_values(10)
-                        self._insert_test_data(cursor, random_value)
+                        self._insert_random_value(cursor, random_value)
         except RetryError:
             logger.exception("Unable to write to the database")
             return random_value

--- a/src/continuous_writes.py
+++ b/src/continuous_writes.py
@@ -22,7 +22,12 @@ def continuous_writes(database_config: Dict, table_name: str, starting_number: i
     try:
         with MySQLConnector(database_config) as cursor:
             cursor.execute(
-                f"CREATE TABLE IF NOT EXISTS `{table_name}`(number INTEGER, PRIMARY KEY(number));"
+                (
+                    f"CREATE TABLE IF NOT EXISTS `{table_name}`("
+                    "id INTEGER NOT NULL AUTO_INCREMENT,"
+                    "number INTEGER, "
+                    "PRIMARY KEY(id));"
+                )
             )
     except Exception:
         pass

--- a/src/literals.py
+++ b/src/literals.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test application literals."""
+
+CONTINUOUS_WRITE_TABLE_NAME = "data"
+DATABASE_NAME = "continuous_writes_database"
+DATABASE_RELATION = "database"
+LEGACY_MYSQL_RELATION = "mysql"  # MariaDB legacy relation
+PEER = "application-peers"
+PROC_PID_KEY = "proc-pid"
+RANDOM_VALUE_KEY = "inserted_value"
+RANDOM_VALUE_TABLE_NAME = "random_data"

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -1,0 +1,73 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for handling legacy MySQL/MariaDB relations."""
+
+import logging
+
+from ops.model import ActiveStatus, BlockedStatus
+
+from literals import DATABASE_NAME, LEGACY_MYSQL_RELATION
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+
+class LegacyMySQL(Object):
+    """Class for handling legacy MySQL/MariaDB relations."""
+
+    def __init__(self, charm):
+        super().__init__(charm, LEGACY_MYSQL_RELATION)
+        self.charm = charm
+
+        self.framework.observe(
+            charm.on[LEGACY_MYSQL_RELATION].relation_joined, self._on_relation_joined
+        )
+        self.framework.observe(
+            charm.on[LEGACY_MYSQL_RELATION].relation_broken, self._on_relation_broken
+        )
+
+    def _on_relation_joined(self, event):
+        if not self.charm.unit.is_leader():
+            # only leader handles the relation data
+            return
+
+        # On legacy MariaDB, the relation data is stored on
+        # leader unit databag only.
+        try:
+            relation_data = event.relation.data[event.unit]
+        except KeyError:
+            logger.debug("Relation departed")
+            return
+
+        if "user" not in relation_data:
+            if f"{LEGACY_MYSQL_RELATION}-user" in self.charm.app_peer_data:
+                # If user set, relation joined already handled
+                return
+            logger.debug("Relation data not ready yet")
+            event.defer()
+            return
+
+        database_name = relation_data["database"]
+        if database_name != DATABASE_NAME:
+            logger.error(f"Database must be set to {DATABASE_NAME}. Modify the test.")
+            self.charm.unit.status = BlockedStatus("Wrong database name")
+            return
+
+        # Dump data into peer relation
+        self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-user"] = relation_data["user"]
+        self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-password"] = relation_data["password"]
+        self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-host"] = relation_data["host"]
+        self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-database"] = database_name
+        # set charm status
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_relation_broken(self, _):
+        if not self.charm.unit.is_leader():
+            # only leader handles the relation data
+            return
+        # Clear data from peer relation
+        self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-user", None)
+        self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-password", None)
+        self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-host", None)
+        self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-database", None)

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -62,9 +62,6 @@ class LegacyMySQL(Object):
         # Set database-start to true to trigger common post relation tasks
         self.charm.app_peer_data["database-start"] = "true"
 
-        # set charm status
-        self.charm.unit.status = ActiveStatus()
-
     def _on_relation_broken(self, _):
         if not self.charm.unit.is_leader():
             # only leader handles the relation data

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -5,10 +5,9 @@
 
 import logging
 
-from ops.model import ActiveStatus, BlockedStatus
-
 from literals import DATABASE_NAME, LEGACY_MYSQL_RELATION
 from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus
 
 logger = logging.getLogger(__name__)
 
@@ -44,13 +43,13 @@ class LegacyMySQL(Object):
             if f"{LEGACY_MYSQL_RELATION}-user" in self.charm.app_peer_data:
                 # If user set, relation joined already handled
                 return
-            logger.debug("Relation data not ready yet")
+            logger.debug("Mysql legacy relation data not ready yet. Deferring event.")
             event.defer()
             return
 
         database_name = relation_data["database"]
         if database_name != DATABASE_NAME:
-            logger.error(f"Database must be set to {DATABASE_NAME}. Modify the test.")
+            logger.error(f"Database name must be set to `{DATABASE_NAME}`. Modify the test.")
             self.charm.unit.status = BlockedStatus("Wrong database name")
             return
 
@@ -59,6 +58,10 @@ class LegacyMySQL(Object):
         self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-password"] = relation_data["password"]
         self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-host"] = relation_data["host"]
         self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-database"] = database_name
+
+        # Set database-start to true to trigger common post relation tasks
+        self.charm.app_peer_data["database-start"] = "true"
+
         # set charm status
         self.charm.unit.status = ActiveStatus()
 

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -7,7 +7,7 @@ import logging
 
 from literals import DATABASE_NAME, LEGACY_MYSQL_RELATION
 from ops.framework import Object
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import BlockedStatus
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,9 @@ class LegacyMySQL(Object):
         )
         self.framework.observe(
             charm.on[LEGACY_MYSQL_RELATION].relation_broken, self._on_relation_broken
+        )
+        self.framework.observe(
+            charm.on.get_legacy_mysql_credentials_action, self._get_legacy_mysql_credentials
         )
 
     def _on_relation_joined(self, event):
@@ -71,3 +74,14 @@ class LegacyMySQL(Object):
         self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-password", None)
         self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-host", None)
         self.charm.app_peer_data.pop(f"{LEGACY_MYSQL_RELATION}-database", None)
+
+    def _get_legacy_mysql_credentials(self, event) -> None:
+        """Retrieve legacy mariadb credentials."""
+        event.set_results(
+            {
+                "username": self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-user"],
+                "password": self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-password"],
+                "host": self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-host"],
+                "database": self.charm.app_peer_data[f"{LEGACY_MYSQL_RELATION}-database"],
+            }
+        )


### PR DESCRIPTION
## Issue

Usage of mysql-test-app all across our charm tests, replacing test applications within the test code.
Tests that use 3rd party apps for testing should remain the same.

Part of [DPE-1465](https://warthogs.atlassian.net/browse/DPE-1465)

## Solution

Added support for a mysql/mariadb legacy relation



[DPE-1465]: https://warthogs.atlassian.net/browse/DPE-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ