### PR TITLE
[DPE-2853][FIX] Stuck in 'waiting' if secrets weren't distributed before `start` event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -82,6 +82,9 @@ class MySQLTestApplication(CharmBase):
             getattr(self.database.on, "endpoints_changed"), self._on_endpoints_changed
         )
         self.framework.observe(
+            self.on[DATABASE_RELATION].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
             self.on[DATABASE_RELATION].relation_broken, self._on_relation_broken
         )
         self.framework.observe(
@@ -328,6 +331,13 @@ class MySQLTestApplication(CharmBase):
                 self.app_peer_data["database-start"] = "done"
 
             self.unit.status = ActiveStatus()
+
+    def _on_relation_changed(self, _) -> None:
+        """Handle the database relation broken event."""
+        if self._database_config:
+            self.unit.status = ActiveStatus()
+        else:
+            self.unit.status = WaitingStatus()
 
     def _on_relation_broken(self, _) -> None:
         """Handle the database relation broken event."""


### PR DESCRIPTION
Registering relation-changed, preventing to be stuck in 'waiting'…if secrets weren't there at 'start'.

# Issue

Currently if secrets aren't available before the `start` event, the evaluation on `_datbase_confg` returns an empty value, leaving the unit in `Waiting` state. However, even if the secrets become available, there's no further evaluation on this condition.

# Solution

As for now, a `relation-changed` event allows for re-evaluation of the condition. (
This shouldn't interfere with the single other event that's modifying the state, which is `relation-broken`)

**NOTE**: Purposefully not updating libs now. `data_platform_llibs/data_interfaces` v21 is broken, and the fix is just being merged.