### PR TITLE
Create config for database name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,7 @@ options:
     description: "Whether to auto start continuous writes on relation events."
     type: boolean
     default: true
+  database_name:
+    description: "Name of database to direct continuous writes to"
+    type: string
+    default: "continuous_writes_database"

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,7 +76,9 @@ class MySQLTestApplication(CharmBase):
         )
 
         # Database related events
-        self.database = DatabaseRequires(self, relation_name="database", database_name=self.database_name)
+        self.database = DatabaseRequires(
+            self, relation_name="database", database_name=self.database_name
+        )
         self.framework.observe(
             getattr(self.database.on, "database_created"), self._on_database_created
         )
@@ -122,6 +124,7 @@ class MySQLTestApplication(CharmBase):
 
     @property
     def database_name(self) -> str:
+        """Returns the database name for the continuous writes."""
         return self.config["database_name"]
 
     @property
@@ -274,7 +277,7 @@ class MySQLTestApplication(CharmBase):
     # Handlers
     # ==============
     def _on_config_changed(self, event: EventBase) -> None:
-        """Handle config changes, especially database_name"""
+        """Handle config changes, especially database_name."""
         logger.warning("Please unrelate and re-relate after updating the database_name config")
 
     def _on_start(self, _) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ import subprocess
 from typing import Dict, Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from ops import EventBase
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, Relation, WaitingStatus
@@ -24,7 +25,6 @@ from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 from connector import MySQLConnector  # isort: skip
 from literals import (
     CONTINUOUS_WRITE_TABLE_NAME,
-    DATABASE_NAME,
     DATABASE_RELATION,
     LEGACY_MYSQL_RELATION,
     PEER,
@@ -45,6 +45,7 @@ class MySQLTestApplication(CharmBase):
 
         # Charm events
         self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on[PEER].relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
@@ -75,7 +76,7 @@ class MySQLTestApplication(CharmBase):
         )
 
         # Database related events
-        self.database = DatabaseRequires(self, "database", DATABASE_NAME)
+        self.database = DatabaseRequires(self, relation_name="database", database_name=self.database_name)
         self.framework.observe(
             getattr(self.database.on, "database_created"), self._on_database_created
         )
@@ -120,6 +121,10 @@ class MySQLTestApplication(CharmBase):
         return self._peers.data[self.unit]
 
     @property
+    def database_name(self) -> str:
+        return self.config["database_name"]
+
+    @property
     def _database_config(self):
         """Returns the database config to use to connect to the MySQL cluster."""
         # identify the database relation
@@ -144,7 +149,7 @@ class MySQLTestApplication(CharmBase):
         config = {
             "user": username,
             "password": password,
-            "database": DATABASE_NAME,
+            "database": self.database_name,
         }
         if endpoints.startswith("file://"):
             config["unix_socket"] = endpoints[7:]
@@ -221,7 +226,7 @@ class MySQLTestApplication(CharmBase):
 
         with MySQLConnector(self._database_config) as cursor:
             cursor.execute(
-                f"SELECT MAX(number) FROM `{DATABASE_NAME}`.`{CONTINUOUS_WRITE_TABLE_NAME}`;"
+                f"SELECT MAX(number) FROM `{self.database_name}`.`{CONTINUOUS_WRITE_TABLE_NAME}`;"
             )
             return cursor.fetchone()[0]
 
@@ -268,6 +273,10 @@ class MySQLTestApplication(CharmBase):
     # ==============
     # Handlers
     # ==============
+    def _on_config_changed(self, event: EventBase) -> None:
+        """Handle config changes, especially database_name"""
+        logger.warning("Please unrelate and re-relate after updating the database_name config")
+
     def _on_start(self, _) -> None:
         """Handle the start event."""
         self.unit.set_workload_version("0.0.2")
@@ -275,6 +284,7 @@ class MySQLTestApplication(CharmBase):
             self.unit.status = ActiveStatus()
         else:
             self.unit.status = WaitingStatus()
+        self.app_peer_data["initialized"] = "true"
 
     def _on_clear_continuous_writes_action(self, _) -> None:
         """Handle the clear continuous writes action event."""
@@ -284,7 +294,7 @@ class MySQLTestApplication(CharmBase):
         self._stop_continuous_writes()
         with MySQLConnector(self._database_config) as cursor:
             cursor.execute(
-                f"DROP TABLE IF EXISTS `{DATABASE_NAME}`.`{CONTINUOUS_WRITE_TABLE_NAME}`;"
+                f"DROP TABLE IF EXISTS `{self.database_name}`.`{CONTINUOUS_WRITE_TABLE_NAME}`;"
             )
 
     def _on_start_continuous_writes_action(self, _) -> None:

--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,6 @@
 """Test application literals."""
 
 CONTINUOUS_WRITE_TABLE_NAME = "data"
-DATABASE_NAME = "continuous_writes_database"
 DATABASE_RELATION = "database"
 LEGACY_MYSQL_RELATION = "mysql"  # MariaDB legacy relation
 PEER = "application-peers"

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -60,7 +60,9 @@ class LegacyMySQL(Object):
 
         database_name = relation_data["database"]
         if database_name != self.charm.database_name:
-            logger.error(f"Database name must be set to `{self.charm.database_name}`. Modify the test.")
+            logger.error(
+                f"Database name must be set to `{self.charm.database_name}`. Modify the test."
+            )
             self.charm.unit.status = BlockedStatus("Wrong database name")
             return
 

--- a/src/relations/legacy_mysql.py
+++ b/src/relations/legacy_mysql.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from literals import DATABASE_NAME, LEGACY_MYSQL_RELATION
+from literals import LEGACY_MYSQL_RELATION
 from ops import Object, RelationChangedEvent
 from ops.model import BlockedStatus
 
@@ -59,8 +59,8 @@ class LegacyMySQL(Object):
             return
 
         database_name = relation_data["database"]
-        if database_name != DATABASE_NAME:
-            logger.error(f"Database name must be set to `{DATABASE_NAME}`. Modify the test.")
+        if database_name != self.charm.database_name:
+            logger.error(f"Database name must be set to `{self.charm.database_name}`. Modify the test.")
             self.charm.unit.status = BlockedStatus("Wrong database name")
             return
 


### PR DESCRIPTION
## Issue
We are unable to specify a database name for mysql-test-app. This prevents us from relating multiple test apps to the same router (in order to test the many-to-one `database` interface)

## Solution
- Add the database name as a config
- Warn users to unrelate and rerelate if the `database_name` config option has changed