### PR TITLE
Update mysql-connector-python to 8.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops >= 2.0.0
 tenacity==8.1.0
-mysql-connector-python~=8.0.33
+mysql-connector-python~=8.4.0


### PR DESCRIPTION
mysql-connector-python 8.0.33 does not have a binary wheel for linux arm64 (only 8.1.0+ has wheel): https://pypi.org/project/mysql-connector-python/8.0.33/#files

This causes integration tests on mysql-operator to fail: https://github.com/canonical/mysql-operator/actions/runs/9757771610/job/26931222576#step:23:607

> The latest MySQL Connector/Python version is recommended for use with MySQL Server version 8.0 and higher.

https://dev.mysql.com/doc/connector-python/en/

8.4.0 connector supports server 8.0: https://dev.mysql.com/doc/connector-python/en/connector-python-versions.html