### PR TITLE
DPE-5397 Avoid break tests on clear continuous writes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -348,6 +348,12 @@ class MySQLTestApplication(CharmBase):
 
     def _on_endpoints_changed(self, _) -> None:
         """Handle the database endpoints changed event."""
+        if self.is_writes_running:
+            logger.debug("Restarting continuous writes due to endpoints change")
+            self._stop_continuous_writes()
+            self._on_start_continuous_writes_action(None)
+            return
+
         if self.config["auto_start_writes"]:
             count = self._max_written_value()
             self._start_continuous_writes(count + 1)

--- a/src/connector.py
+++ b/src/connector.py
@@ -6,7 +6,7 @@
 
 import signal
 
-import mysql.connector
+import mysql.connector as connector
 
 
 def timeout_handler(signum, frame):
@@ -39,7 +39,7 @@ class MySQLConnector:
 
     def __enter__(self):
         """Create the connection and return a cursor."""
-        self.connection = mysql.connector.connect(**self.config)
+        self.connection = connector.connect(**self.config)
         self.cursor = self.connection.cursor()
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(self.query_timeout)


### PR DESCRIPTION
## Issue

Some test fails due clear-continuous-writes action failing.
It can happens due endpoint changes not restarting the writer, i.e. using outdated endpoint.

There's also no drawback on not failing the action for database relation errors, since it's not used to assert anything.

## Solution
- wont fail drop test table 
- restart writer on endpoint change

Tested on [mysql-vm](https://github.com/canonical/mysql-operator/pull/521)