### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,13 @@ skip_missing_interpreters = True
 envlist = fmt, lint, unit
 
 [vars]
-src_path = {toxinidir}/src/
-;tst_path = {toxinidir}/tests/
+src_path = "{toxinidir}/src"
+;tst_path = "{toxinidir}/tests"
 all_path = {[vars]src_path} 
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{toxinidir}/src
   PYTHONBREAKPOINT=pdb.set_trace
   PY_COLORS=1
 passenv =
@@ -36,14 +36,14 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir} \
-              --skip {toxinidir}/.git \
-              --skip {toxinidir}/.tox \
-              --skip {toxinidir}/build \
-              --skip {toxinidir}/lib \
-              --skip {toxinidir}/venv \
-              --skip {toxinidir}/.mypy_cache \
-              --skip {toxinidir}/icon.svg
+    codespell "{toxinidir}" \
+              --skip "{toxinidir}/.git" \
+              --skip "{toxinidir}/.tox" \
+              --skip "{toxinidir}/build" \
+              --skip "{toxinidir}/lib" \
+              --skip "{toxinidir}/venv" \
+              --skip "{toxinidir}/.mypy_cache" \
+              --skip "{toxinidir}/icon.svg"
     
     ruff check {[vars]all_path}
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist = fmt, lint, unit
 
 [vars]
 src_path = "{toxinidir}/src"
-;tst_path = "{toxinidir}/tests"
 all_path = {[vars]src_path} 
 
 [testenv]


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/mysql-test-app/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/MySQL"
$ cd "Projects/Canonical/Data Platform/MySQL"
$ git clone https://github.com/canonical/mysql-test-app
$ cd mysql-test-app
$ tox run -e fmt
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-test-app/src:1:1: E902 No such file or directory (os error 2)
> Platform/MySQL/mysql-test-app/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.