### PR TITLE
[MISC] Run the continuous writes script with the charm's python

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,6 @@ high availability of the MySQL charm.
 """
 
 import logging
-import pathlib
 import re
 import secrets
 import string
@@ -186,10 +185,8 @@ class MySQLTestApplication(CharmBase):
 
         self._stop_continuous_writes()
 
-        python_binary = pathlib.Path(__file__).parent.parent / "venv" / "bin" / "python"
-
         command = [
-            python_binary,
+            "venv/bin/python",
             "src/continuous_writes.py",
             self._database_config["user"],
             self._database_config["password"],

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ high availability of the MySQL charm.
 """
 
 import logging
-import os
+import pathlib
 import re
 import secrets
 import string
@@ -186,8 +186,7 @@ class MySQLTestApplication(CharmBase):
 
         self._stop_continuous_writes()
 
-        current_directory = os.path.dirname(os.path.realpath(__file__))
-        python_binary = os.path.join(current_directory, "../venv/bin/python")
+        python_binary = pathlib.Path(__file__).parent.parent / "venv" / "bin" / "python"
 
         command = [
             python_binary,

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ high availability of the MySQL charm.
 """
 
 import logging
+import os
 import re
 import secrets
 import string
@@ -185,8 +186,11 @@ class MySQLTestApplication(CharmBase):
 
         self._stop_continuous_writes()
 
+        current_directory = os.path.dirname(os.path.realpath(__file__))
+        python_binary = os.path.join(current_directory, "../venv/bin/python")
+
         command = [
-            "/usr/bin/python3",
+            python_binary,
             "src/continuous_writes.py",
             self._database_config["user"],
             self._database_config["password"],


### PR DESCRIPTION
## Issue
When we use `/usr/bin/python3` to invoke the continuous writes script, it does not have `mysql-connector-python` installed. This is because charmcraft (to my understanding) installs packages for the charm in a `venv/` in the charm's root path. This causes the continuous writes script to fail with the following error:

```
unit-mysql-test-app-0: 20:30:57 INFO unit.mysql-test-app/0.juju-log Started continuous writes                                                                                                                      
unit-mysql-test-app-0: 20:30:57 WARNING unit.mysql-test-app/0.start-continuous-writes Traceback (most recent call last):                                                                                           
unit-mysql-test-app-0: 20:30:57 WARNING unit.mysql-test-app/0.start-continuous-writes   File "/var/lib/juju/agents/unit-mysql-test-app-0/charm/src/continuous_writes.py", line 10, in <module>                     
unit-mysql-test-app-0: 20:30:57 WARNING unit.mysql-test-app/0.start-continuous-writes     import mysql.connector                                                                                                   
unit-mysql-test-app-0: 20:30:57 WARNING unit.mysql-test-app/0.start-continuous-writes ModuleNotFoundError: No module named 'mysql'                                                                                 
unit-mysql-0: 20:32:20 INFO unit.mysql/0.juju-log Unit workload member-state is online with member-role secondary           
```

## Solution
Invoke the script with not the system's python, but rather the python used for the charm (which will be configured to refer to the charm's dependencies in `$CHARM_ROOT/venv/`