### PR TITLE
Drop 20.04 base to fix build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,8 +3,6 @@
 
 type: charm
 platforms:
-  ubuntu@20.04:amd64:
-  ubuntu@20.04:arm64:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
 # Files implicitly created by charmcraft without a part:


### PR DESCRIPTION
Build currently broken on main for 20.04 https://github.com/canonical/mysql-test-app/actions/runs/16566892439/job/46849078504

20.04 no longer needed now that mysql-router VM dropped 20.04 support