### PR TITLE
[DPE-7322] Shorten default database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ On using the `mysql` legacy relation interface with either [mysql] or [mysql-k8s
 necessary to config the database name with:
 
 ```shell
-> juju config mysql-k8s mysql-interface-database=continuous_writes_database
+> juju config mysql-k8s mysql-interface-database=continuous_writes
 ```
 
 ## Actions

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ options:
   database_name:
     description: "Name of database to direct continuous writes to"
     type: string
-    default: "continuous_writes_database"
+    default: "continuous_writes"
   sleep_interval:
     description: "How many milliseconds to sleep between writes"
     default: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
+ignore = ["E501", "D107"]
 extend-ignore = [
     "D203",
     "D204",
@@ -48,9 +52,15 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104"
+]
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ description = Apply coding style standards to code
 deps =
     ruff
 commands =
-    ruff {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards


### PR DESCRIPTION
This PR shortens the default database name, in order for integration tests across operators (VM & K8s) to be able to create the corresponding predefined roles, without overriding the database name. This is necessary due to MySQL role name 32 character limit, which `charmed_dba_continuous_writes_database` surpasses.

Addresses [this comment](https://github.com/canonical/mysql-operator/pull/652#discussion_r2266803878).