### PR TITLE
[DPE-8811] Default to Ubuntu 24.04 platform (II)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,6 +3,9 @@
 
 type: charm
 platforms:
+  ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
+  ubuntu@22.04:s390x:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
   ubuntu@24.04:s390x:
@@ -25,9 +28,21 @@ parts:
       - libssl-dev  # Needed to build Python dependencies with Rust from source to install Poetry on s390x
       - pkg-config  # Needed to build Python dependencies with Rust from source to install Poetry on s390x
     override-build: |
-      python3 -m pip install --user --break-system-packages --upgrade pip==24.3.1  # renovate: charmcraft-pip-latest
-      python3 -m pip install --user --break-system-packages poetry==2.0.1          # renovate: charmcraft-poetry-latest
-      python3 -m pip install --user --break-system-packages poetry-plugin-export==1.9.0
+      # Use environment variable instead of `--break-system-packages` to avoid failing on older
+      # versions of pip that do not recognize `--break-system-packages`
+      # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==24.3.1  # renovate: charmcraft-pip-latest
+
+      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
+      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.20/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
+      # poetry 2.0.0 requires Python >=3.9
+      if ! "$HOME/.local/bin/uv" python find '>=3.9'
+      then
+        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
+        # (to reduce the number of Python versions we use)
+        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
+      fi
+      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.0.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
 
       ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
   # "charm-poetry" part name is arbitrary; use for consistency

--- a/poetry.lock
+++ b/poetry.lock
@@ -161,5 +161,5 @@ test = ["websockets"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12"
-content-hash = "519acde4b2673457f4f9d6a313ab36d92afd5a5c8e0afa93c44a93cae1ca15c5"
+python-versions = ">=3.10"
+content-hash = "bda047d1bf830b1fb93b67e2ee7c57372750756a8bfea93f44cff67ffb5ae09d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ package-mode = false
 requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
-python = ">=3.12"
+python = ">=3.10"
 ops = "^2.0.0"
 tenacity = "^8.1.0"
 mysql-connector-python = "^9.4.0"
@@ -29,7 +29,7 @@ log_cli_level = "INFO"
 # Formatting tools configuration
 [tool.black]
 line-length = 99
-target-version = ["py312"]
+target-version = ["py310"]
 
 # Linting tools configuration
 [tool.ruff]


### PR DESCRIPTION
This PR re-adds Ubuntu 22.04 as a build platform.

Apparently, neither `ops.test` nor Charmhub is smart enough to fallback to an older revision, within the desired channel, supporting the desired base. The last revision of a channel must support all desired platforms.

---

Fixes https://github.com/canonical/mysql-router-operators/pull/88.