### PR TITLE
[MISC] Cleanup CI cache flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,5 +25,3 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.2.0
-    with:
-      cache: false  # TODO: cleanup


### PR DESCRIPTION
This PR cleans up the usage of the build step cache flag, now that the Python packages cache is available.