### PR TITLE
[DPE-9970] Build for Ubuntu 26.04 base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.2.0
+    with:
+      cache: false

--- a/README.md
+++ b/README.md
@@ -25,14 +25,10 @@ Actions are listed on [actions page](https://charmhub.io/mysql-test-app/actions)
 
 ## References
 * [MySQL Test App](https://charmhub.io/mysql-test-app)
-* [mysql-k8s](https://charmhub.io/mysql-k8s)
 * [mysql](https://charmhub.io/mysql)
+* [mysql-k8s](https://charmhub.io/mysql-k8s)
+* [mysql-router](https://charmhub.io/mysql-router)
 * [mysql-router-k8s](https://charmhub.io/mysql-router-k8s)
-* [mysql-router](https://charmhub.io/mysql-router?channel=dpe/edge)
-* [mysql-bundle-k8s](https://charmhub.io/mysql-bundle-k8s)
-* [mysql-bundle](https://charmhub.io/mysql-bundle)
-* [MySQL Test App at Charmhub](https://charmhub.io/mysql-test-app)
-* [PostgreSQL Test App](https://charmhub.io/postgresql-test-app)
 
 ## Security
 Security issues in the MySQL Test App can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,9 @@ platforms:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
   ubuntu@24.04:s390x:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
+  ubuntu@26.04:s390x:
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,8 +12,6 @@ issues: https://github.com/canonical/mysql-test-app/issues
 website:
   - https://ubuntu.com/data/mysql
   - https://charmhub.io/mysql
-  - https://github.com/canonical/mysql-operator
-  - https://github.com/canonical/mysql-k8s-operator
   - https://chat.charmhub.io/charmhub/channels/data-platform
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>


### PR DESCRIPTION
This PR adds the Ubuntu 26.04 base to the charm.

The Ubuntu 24.04 base will only be ready to be cleanup up once all operators that use it for integration tests purposes (i.e. mysql-operators, mysql-router-operators...) have upgraded as well.