### PR TITLE
[MISC] Enable CI build step cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,5 +25,3 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.2.0
-    with:
-      cache: false


### PR DESCRIPTION
This PR enables back the building cache, after the charm dependencies have been built for Ubuntu 26.04 (see [CI run](https://github.com/canonical/charmcraftcache-hub/actions/runs/26605753561)).