### PR TITLE
[MISC] Fix unset timer reset

### DIFF
--- a/src/connector.py
+++ b/src/connector.py
@@ -48,8 +48,10 @@ class MySQLConnector:
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Handle transaction and connection close."""
         del exc_val, exc_tb
-        if self.commit and exc_type is None:
-            self.connection.commit()
-        self.cursor.close()
-        self.connection.close()
-        signal.alarm(0)
+        try:
+            if self.commit and exc_type is None:
+                self.connection.commit()
+            self.cursor.close()
+            self.connection.close()
+        finally:
+            signal.alarm(0)


### PR DESCRIPTION
Uncaught exception in connector `__exit__` method will fail to reset timeout timer and raise a `TimeoutError`.
This silently crashes the continuous_writes script, causing some tests to fail.