### PR TITLE
[MISC] Remove Ubuntu 24.04 base

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,23 +13,6 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
 
-  release-libraries:
-    name: Release libraries
-    needs:
-      - ci-tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Release charm libraries
-        uses: canonical/charming-actions/release-libraries@2.3.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
   release:
     name: Release charm
     needs:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,9 +6,6 @@ platforms:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
   ubuntu@22.04:s390x:
-  ubuntu@24.04:amd64:
-  ubuntu@24.04:arm64:
-  ubuntu@24.04:s390x:
   ubuntu@26.04:amd64:
   ubuntu@26.04:arm64:
   ubuntu@26.04:s390x:


### PR DESCRIPTION
This PR removes the Ubuntu 24.04 base, now that both MySQL Server / Router 8.4 have been built for 26.04.