### PR TITLE
[MISC] Add external-node-connectivity flag

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -82,7 +82,10 @@ class MySQLTestApplication(CharmBase):
 
         # Database related events
         self.database = DatabaseRequires(
-            self, relation_name="database", database_name=self.database_name
+            charm=self,
+            relation_name="database",
+            database_name=self.database_name,
+            external_node_connectivity=True,
         )
         self.framework.observe(
             getattr(self.database.on, "database_created"), self._on_database_created


### PR DESCRIPTION
This PR includes the `external-node-connectivity` flag in the relation databag. This is needed in order to be able to access the MySQL Server database, from a MySQL Router instance, running commands on a host machine.

---

Unblocks PR https://github.com/canonical/mysql-router-operators/pull/191.