### PR TITLE
[MISC] Restart dead continuous writes process in update-status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -414,6 +414,10 @@ class MySQLTestApplication(CharmBase):
     def _on_update_status(self, _) -> None:
         """Get last written value and update status."""
         if self.unit_peer_data.get(PROC_PID_KEY):
+            if not self.is_writes_running:
+                # Process died but was not stopped cleanly, restart it
+                logger.info("Continuous writes process not running, restarting")
+                self._on_start_continuous_writes_action(None)
             try:
                 value = self._max_written_value()
                 if value > 0:


### PR DESCRIPTION
If the continuous writes process dies but _stop_continuous_writes is never called (e.g. the process is killed by OOM or signal), the PROC_PID_KEY stays set but the process is gone. _on_update_status now checks if the process is running and restarts it if not.